### PR TITLE
Add ZNC as a source for logs

### DIFF
--- a/markovgen/markovgen.py
+++ b/markovgen/markovgen.py
@@ -139,7 +139,8 @@ REGEXPS = {
     'xchat': '[a-z.]+ [0-9]+ [0-9:]+ <[^ ]+> (<[^ ]+> )?(?P<message>.*)$',
     'supybot': '^[^ ]*  (<[^ ]+> )?(?P<message>.*)$',
     'srt': '^(?P<message>[^0-9].*)$',
-    'plain': '^(?P<message>.*)$'
+    'plain': '^(?P<message>.*)$',
+    'znc': '^\[[0-9]+:[0-9]+:[0-9]+\] (<[^ ]+> )?(?P<message>.*)$'
 }
 
 


### PR DESCRIPTION
This commit adds ZNC as a source for logs, using the default timestamp config.